### PR TITLE
Fix frontend auth base URL

### DIFF
--- a/frontend/src/components/LoginForm.js
+++ b/frontend/src/components/LoginForm.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import RegisterForm from './RegisterForm';
+import { BASE_URL } from '../services/api';
 
 function LoginForm({ onLogin }) {
     const [email, setEmail] = useState('');
@@ -12,7 +13,7 @@ function LoginForm({ onLogin }) {
         setError(null);
 
         try {
-            const res = await fetch(`${process.env.REACT_APP_BACKEND_URL}/auth/login`, {
+            const res = await fetch(`${BASE_URL}/auth/login`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ email, password })

--- a/frontend/src/components/RegisterForm.js
+++ b/frontend/src/components/RegisterForm.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { BASE_URL } from '../services/api';
 
 function LoginRegisterForm({ onLogin }) {
     const [isLogin, setIsLogin] = useState(true);
@@ -13,8 +14,8 @@ function LoginRegisterForm({ onLogin }) {
         const endpoint = isLogin ? 'login' : 'register';
 
         try {
-            console.log(`Enviando solicitud de ${isLogin ? 'inicio de sesión' : 'registro'} a ${process.env.REACT_APP_BACKEND_URL}/auth/${endpoint}`);
-            const res = await fetch(`${process.env.REACT_APP_BACKEND_URL}/auth/${endpoint}`, {
+            console.log(`Enviando solicitud de ${isLogin ? 'inicio de sesión' : 'registro'} a ${BASE_URL}/auth/${endpoint}`);
+            const res = await fetch(`${BASE_URL}/auth/${endpoint}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ email, password })

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,4 @@
-const BASE_URL = process.env.REACT_APP_BACKEND_URL;
+export const BASE_URL = process.env.REACT_APP_BACKEND_URL || '/api';
 
 export async function checkServerStatus() {
   const res = await fetch(`${BASE_URL}/sonarqube/status`);


### PR DESCRIPTION
## Summary
- centralize backend URL in `BASE_URL`
- use `BASE_URL` for login and register requests

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f9b16bbc08328a58063c1b25da240